### PR TITLE
More cmdline options

### DIFF
--- a/src/com/newgrounds/swivel/Swivel.hx
+++ b/src/com/newgrounds/swivel/Swivel.hx
@@ -206,9 +206,6 @@ class Swivel extends Application
 		if(arg.charAt(0) == "-") {
 			var sw = arg.substr(1);
 			switch(sw) {
-				// Additional desired switches:
-				//  - PNG output
-				//  - keyframes-every (-g 1)
 				case "s":
 					var parts = args.shift().split("x");
 					_controller.outputWidth = Std.parseInt(parts[0]);
@@ -257,10 +254,10 @@ class Swivel extends Application
 					_controller.transparentBackground = true;
 				
 				case "png":
-					_controller.pngOutput = true;
+					_controller.pngFile = _cmdLineDirectory.resolvePath( StringTools.trim(args.shift()) );
 					
 				case "k":
-					_controller.keyframeEvery = Std.parseInt(arg);
+					_controller.keyframeEvery = Std.parseInt(args.shift());
 					
 				case "o":
 					_controller.outputFile = _cmdLineDirectory.resolvePath( StringTools.trim(args.shift()) );

--- a/src/com/newgrounds/swivel/Swivel.hx
+++ b/src/com/newgrounds/swivel/Swivel.hx
@@ -206,6 +206,9 @@ class Swivel extends Application
 		if(arg.charAt(0) == "-") {
 			var sw = arg.substr(1);
 			switch(sw) {
+				// Additional desired switches:
+				//  - PNG output
+				//  - keyframes-every (-g 1)
 				case "s":
 					var parts = args.shift().split("x");
 					_controller.outputWidth = Std.parseInt(parts[0]);
@@ -252,10 +255,16 @@ class Swivel extends Application
 					
 				case "t":
 					_controller.transparentBackground = true;
+				
+				case "png":
+					_controller.pngOutput = true;
+					
+				case "k":
+					_controller.keyframeEvery = Std.parseInt(arg);
 					
 				case "o":
 					_controller.outputFile = _cmdLineDirectory.resolvePath( StringTools.trim(args.shift()) );
-					
+				
 				default: throw('Invalid switch $sw');
 			}
 		} else {

--- a/src/com/newgrounds/swivel/SwivelController.hx
+++ b/src/com/newgrounds/swivel/SwivelController.hx
@@ -59,7 +59,6 @@ class SwivelController extends com.huey.binding.Binding.Bindable implements Cont
 	@forward(_recorder) public var watermark : Null<Watermark>;
 
 	private var _videoFile : File;
-	private var _pngPath : File;
 	private var _audioFile : File;
 	private var _audioOutput : FileStream;
 	@bindable public var outputFile : File;
@@ -68,7 +67,7 @@ class SwivelController extends com.huey.binding.Binding.Bindable implements Cont
 	@bindable public var audioCodec : AudioCodec;
 	public var audioBitRate : Null<Int>;
 	
-	public var pngOutput : Bool = false;
+	public var pngFile : Null<File>;
 	public var keyframeEvery : Null<Int>;
 	
 	private var _parsedSwf : SwivelSwf;
@@ -137,10 +136,7 @@ class SwivelController extends com.huey.binding.Binding.Bindable implements Cont
 		} else {
 			outputFile;
 		}
-		
-		// FIXME: Strip previous extension.  Use this if pngOutput set.
-		_pngPath = outputFile + "_%04d.png";
-		
+				
 		_taskList = new List();
 		_taskList.add( StartEncoder(_videoFile, if(!usesSwfAudio) _audioFile else null) );
 		for(job in jobs) {
@@ -190,7 +186,7 @@ class SwivelController extends com.huey.binding.Binding.Bindable implements Cont
 		_currentJob = null;
 		switch(task) {
 			case StartEncoder(outputFile, inputAudioFile):
-				var ffmpeg = new FfmpegEncoder(videoPreset, videoBitRate, outputFile, _recorder.outputWidth, _recorder.outputHeight, jobs.array[0].swf.frameRate, if(inputAudioFile != null) inputAudioFile.nativePath else null, audioCodec, audioBitRate, if(stereoAudio) 2 else 1);
+				var ffmpeg = new FfmpegEncoder(videoPreset, videoBitRate, outputFile, _recorder.outputWidth, _recorder.outputHeight, jobs.array[0].swf.frameRate, if(inputAudioFile != null) inputAudioFile.nativePath else null, audioCodec, audioBitRate, if(stereoAudio) 2 else 1, pngFile, keyframeEvery);
 				ffmpeg.onComplete.add(onEncodingComplete);
 				_ffmpeg = ffmpeg;
 				runNextTask();

--- a/src/com/newgrounds/swivel/SwivelController.hx
+++ b/src/com/newgrounds/swivel/SwivelController.hx
@@ -59,6 +59,7 @@ class SwivelController extends com.huey.binding.Binding.Bindable implements Cont
 	@forward(_recorder) public var watermark : Null<Watermark>;
 
 	private var _videoFile : File;
+	private var _pngPath : File;
 	private var _audioFile : File;
 	private var _audioOutput : FileStream;
 	@bindable public var outputFile : File;
@@ -66,6 +67,9 @@ class SwivelController extends com.huey.binding.Binding.Bindable implements Cont
 	public var videoBitRate : Null<Int>;
 	@bindable public var audioCodec : AudioCodec;
 	public var audioBitRate : Null<Int>;
+	
+	public var pngOutput : Bool = false;
+	public var keyframeEvery : Null<Int>;
 	
 	private var _parsedSwf : SwivelSwf;
 		
@@ -133,7 +137,10 @@ class SwivelController extends com.huey.binding.Binding.Bindable implements Cont
 		} else {
 			outputFile;
 		}
-				
+		
+		// FIXME: Strip previous extension.  Use this if pngOutput set.
+		_pngPath = outputFile + "_%04d.png";
+		
 		_taskList = new List();
 		_taskList.add( StartEncoder(_videoFile, if(!usesSwfAudio) _audioFile else null) );
 		for(job in jobs) {

--- a/src/com/newgrounds/swivel/ffmpeg/FfmpegProcess.hx
+++ b/src/com/newgrounds/swivel/ffmpeg/FfmpegProcess.hx
@@ -169,7 +169,7 @@ class FfmpegEncoder extends FfmpegProcess
 	
 	public var onFrameReceived(default, null) : Dispatcher<Dynamic>;
 	
-	public function new(preset : VideoPreset, videoBitRate : Null<Int>, outputFile : File, width : UInt, height : UInt, frameRate : Float, ?audioFile : String, ?audioCodec : AudioCodec, ?audioBitRate : Null<Int>, ?numChannels : Int, ?pngPath : File, ?keyframeEvery : Null<Int>) {
+	public function new(preset : VideoPreset, videoBitRate : Null<Int>, outputFile : File, width : UInt, height : UInt, frameRate : Float, ?audioFile : String, ?audioCodec : AudioCodec, ?audioBitRate : Null<Int>, ?numChannels : Int, ?pngFile : File, ?keyframeEvery : Null<Int>) {
 		_framesSent = _framesReceived = _framesEncoded = 0;
 		_frameQueue = new Array();
 			
@@ -232,11 +232,11 @@ class FfmpegEncoder extends FfmpegProcess
 		
 		params.push(outputFile.nativePath);
 
-		if (pngOutput == true) {
+		if (pngFile != null) {
 			params.push("-an");
 			params.push("-c:v");
 			params.push("png");
-			params.push(pngPath.nativePath);
+			params.push(pngFile.nativePath);
 		}
 		
 

--- a/src/com/newgrounds/swivel/ffmpeg/FfmpegProcess.hx
+++ b/src/com/newgrounds/swivel/ffmpeg/FfmpegProcess.hx
@@ -147,9 +147,9 @@ class FfmpegEncoder extends FfmpegProcess
 	];
 	
 	public static var PRESETS : Array<VideoPreset> = [
-		{label: "H.264 High", fileFormat: "mp4", codec: "libx264", supportsBitRate: true, extraParameters: ["-preset","slow"], supportedAudioCodecs: [AUDIO_CODECS[0], AUDIO_CODECS[2]]},
-		{label: "H.264 Main", fileFormat: "mp4", codec: "libx264", supportsBitRate: true, extraParameters: ["-preset","slow","-profile:v","main"], supportedAudioCodecs: [AUDIO_CODECS[0], AUDIO_CODECS[2]]},
-		{label: "H.264 Baseline", fileFormat: "mp4", codec: "libx264", supportsBitRate: true, extraParameters: ["-preset","slow","-profile:v","baseline"], supportedAudioCodecs: [AUDIO_CODECS[0], AUDIO_CODECS[2]]},
+		{label: "H.264 High", fileFormat: "mp4", codec: "libx264", supportsBitRate: true, extraParameters: ["-preset","slow","-pix_fmt","yuv420p"], supportedAudioCodecs: [AUDIO_CODECS[0], AUDIO_CODECS[2]]},
+		{label: "H.264 Main", fileFormat: "mp4", codec: "libx264", supportsBitRate: true, extraParameters: ["-preset","slow","-profile:v","main","-pix_fmt","yuv420p"], supportedAudioCodecs: [AUDIO_CODECS[0], AUDIO_CODECS[2]]},
+		{label: "H.264 Baseline", fileFormat: "mp4", codec: "libx264", supportsBitRate: true, extraParameters: ["-preset","slow","-profile:v","baseline","-pix_fmt","yuv420p"], supportedAudioCodecs: [AUDIO_CODECS[0], AUDIO_CODECS[2]]},
 		{label: "MPEG-2 Video", fileFormat: "mpg", codec: "mpeg2video", supportsBitRate: true, extraParameters: ["-preset","slow"], supportedAudioCodecs: [AUDIO_CODECS[0], AUDIO_CODECS[2]]},
 		{label: "Theora", fileFormat: "ogg", codec: "theora", supportsBitRate: true, extraParameters: ["-preset","slow"], supportedAudioCodecs: [AUDIO_CODECS[3]]},
 		{label: "QuickTime Animation", fileFormat: "mov", codec: "qtrle", supportsBitRate: false, extraParameters: null,supportedAudioCodecs: [AUDIO_CODECS[0], AUDIO_CODECS[1], AUDIO_CODECS[2]]},

--- a/src/com/newgrounds/swivel/ffmpeg/FfmpegProcess.hx
+++ b/src/com/newgrounds/swivel/ffmpeg/FfmpegProcess.hx
@@ -169,7 +169,7 @@ class FfmpegEncoder extends FfmpegProcess
 	
 	public var onFrameReceived(default, null) : Dispatcher<Dynamic>;
 	
-	public function new(preset : VideoPreset, videoBitRate : Null<Int>, outputFile : File, width : UInt, height : UInt, frameRate : Float, ?audioFile : String, ?audioCodec : AudioCodec, ?audioBitRate : Null<Int>, ?numChannels : Int) {
+	public function new(preset : VideoPreset, videoBitRate : Null<Int>, outputFile : File, width : UInt, height : UInt, frameRate : Float, ?audioFile : String, ?audioCodec : AudioCodec, ?audioBitRate : Null<Int>, ?numChannels : Int, ?pngPath : File, ?keyframeEvery : Null<Int>) {
 		_framesSent = _framesReceived = _framesEncoded = 0;
 		_frameQueue = new Array();
 			
@@ -219,6 +219,11 @@ class FfmpegEncoder extends FfmpegProcess
 			for(p in preset.extraParameters) params.push(p);
 		}
 		
+		if (keyframeEvery != null) {
+			params.push("-g");
+			params.push(Std.string(keyframeEvery));
+		}
+		
 		params.push("-aspect");
 		params.push(width + ":" + height);
 
@@ -226,6 +231,15 @@ class FfmpegEncoder extends FfmpegProcess
 		params.push("-2");
 		
 		params.push(outputFile.nativePath);
+
+		if (pngOutput == true) {
+			params.push("-an");
+			params.push("-c:v");
+			params.push("png");
+			params.push(pngPath.nativePath);
+		}
+		
+
 		
 		super( params );
 	}


### PR DESCRIPTION
I've added a couple of command-line options which we'll be using that would be lovely to have in the master branch.

-png &lt;path/to/namespec_%04d.png&gt;

-k &lt;keyframeEvery&gt; (integer)

The first one is for outputting PNGs (in addition to the MP4).  The second one passes through to the "-g" option in ffmpeg; we primarily use it to make the MP4s frame-by-frame scrubbable for animators.

Let me know what you think.  Thanks!